### PR TITLE
update Django to 2.1.2 (fix vulnerability)

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
-Django==2.1.1
-Pillow==5.2.0
+Django==2.1.2
+Pillow==5.3.0
 dj-database-url==0.5.0
 django-environ==0.4.5
 django-markdownx==2.0.24

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -1,4 +1,4 @@
 -r base.txt
 
-Sphinx==1.8.0
+Sphinx==1.8.1
 sphinx-rtd-theme==0.4.1


### PR DESCRIPTION
### Summary

Upgrade Django from 2.1.1 to 2.1.2

### Benefits

Fix [CVE-2018-16984](https://nvd.nist.gov/vuln/detail/CVE-2018-16984)

### Drawbacks and Risks 

Having seen some exceptions raised in debug mode when using admin sites, but seemingly without impacting the web interface itself.

### Alternate Designs

N/A

### Applicable Issues

N/A